### PR TITLE
Revert "Bump jetty-server from 8.1.16.v20140903 to 9.4.17.v20190418 in /bindings/jabbot-spark-binding"

### DIFF
--- a/bindings/jabbot-spark-binding/pom.xml
+++ b/bindings/jabbot-spark-binding/pom.xml
@@ -39,7 +39,7 @@
 	<dependency>
 		<groupId>org.eclipse.jetty</groupId>
 		<artifactId>jetty-server</artifactId>
-		<version>9.4.17.v20190418</version>
+		<version>8.1.16.v20140903</version>
 	</dependency>
 	<dependency>
 		<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Reverts midoricorp/jabbot#65